### PR TITLE
Divide sparse matrices implementation

### DIFF
--- a/structures/matrices/sparse/sparse.hpp
+++ b/structures/matrices/sparse/sparse.hpp
@@ -1,30 +1,16 @@
-#ifndef MATRICES_SPARSE_BLOCK_HPP_
-#define MATRICES_SPARSE_BLOCK_HPP_
+#ifndef NUMPP_MATRICES_SPARSE_BLOCK_HPP_
+#define NUMPP_MATRICES_SPARSE_BLOCK_HPP_
 
 #include<vector>
-#include<iostream>
-#include<algorithm>
-#include<cmath>
-#include<algorithm>
-#include<array>
 
 #include"../../vector/vector_utils.hpp"
 
 
-namespace numpp::matrix{
-  struct sparse_block{};
-  template<typename T>
-    struct block{
-      public:
-        std::vector<T> data;
-        std::size_t column;
-    };
-  //BLOCK OF CONTIGUOUS DATA IN MATRIX
-
+namespace numpp::matrix::sparse{
   template<typename T, std::size_t Rows, std::size_t Columns>
       //VERSION WITH MAXIMUM POSSIBLE CACHE HIT
       //ANALYZE BLOCK STRUCTURE WHERE THIS STYLE IS PREFFERED
-      class sparse{
+      class block{
         public:
           using value_type = T;
           using size_type = std::size_t;
@@ -33,36 +19,13 @@ namespace numpp::matrix{
           using pointer = T*;
           using const_pointer = const T*;
 
-          using type = sparse_block;
+          block()=default;
+          block(const block&)=default;
+          block(block&&)=default;
+          block& operator=(block&&)=default;
+          block& operator=(const block&)=default;
 
-          sparse()=default;
-          sparse(const sparse&)=default;
-          sparse(sparse&&)=default;
-          sparse& operator=(sparse&&)=default;
-          sparse& operator=(const sparse&)=default;
-
-          sparse(std::initializer_list<std::initializer_list<T>> elements){
-
-            /* for(auto row=std::begin(elements); row!=std::end(elements); ++row){ */
-            /*   std::size_t elements_counter = 0; */
-            /*   const auto iterator_position{std::distance(std::begin(elements), row)}; */
-
-            /*   for(auto col=row->begin(), end=row->end(); col!=end; ++col){ */
-            /*     if(*col != 0){ */
-            /*       numpp::matrix::block<T> chain{}; */
-            /*       chain.column = elements_counter; */
-
-            /*       while((*col != 0) && (col!=end)){ */
-            /*         chain.data.push_back(*col); */
-            /*         ++elements_counter; */
-            /*         ++col; */
-            /*       } */
-            /*       matrix[iterator_position].emplace_back(chain); */
-            /*     } */
-            /*     ++elements_counter; */
-            /*   } */
-            /* } */
-          /* } */
+          block(std::initializer_list<std::initializer_list<T>> elements){
 
             for(auto row=std::begin(elements); row!=std::end(elements); ++row){
              const auto iterator_position{std::distance(std::begin(elements), row)};
@@ -105,11 +68,11 @@ namespace numpp::matrix{
             return matrix.size();
           }
 
-          const std::array<std::vector<block<T>>, Rows>& data() const noexcept{
+          const std::array<std::vector<T>, Rows>& data() const noexcept{
             return matrix;
           }
 
-          std::array<std::vector<block<T>>, Rows>& data() noexcept{
+          std::array<std::vector<T>, Rows>&  data() noexcept{
             return matrix;
           }
 
@@ -119,16 +82,6 @@ namespace numpp::matrix{
 
               #pragma omp for schedule(simd:dynamic)
               for(std::size_t row=0; row<Rows; ++row){
-
-                /* for(std::size_t block=0, block_end=matrix[row].size(); block<block_end; ++block){ */
-
-                /*   const std::size_t col=matrix[row][block].column; */
-                /*   const std::size_t element_end=matrix[row][block].data.size(); */
-                /*   #pragma omp simd */
-                /*   for(std::size_t element=0; element<element_end; ++element){ */
-                /*     output(row) += matrix[row][block].data[element]*vec(col+element); */
-                /*   } */
-                /* } */
 
                 for(std::size_t col=0; col<matrix[row].size(); ++col){
                   std::size_t col_index = static_cast<std::size_t>(matrix[row][col]);
@@ -142,7 +95,6 @@ namespace numpp::matrix{
             }
 
         private:
-          /* std::array<std::vector<block<T>>, Rows> matrix{}; */
           std::array<std::vector<T>, Rows> matrix{};
       };
 }

--- a/structures/matrices/sparse/sparse_nested.hpp
+++ b/structures/matrices/sparse/sparse_nested.hpp
@@ -1,0 +1,97 @@
+#ifndef NUMPP_MATRICES_SPARSE_BLOCK_NESTED_HPP_
+#define NUMPP_MATRICES_SPARSE_BLOCK_NESTED_HPP_
+
+#include<vector>
+
+#include"../../vector/vector_utils.hpp"
+
+
+namespace numpp::matrix::sparse{
+  template<typename T>
+    struct inner_block{
+      public:
+        std::vector<T> data;
+        std::size_t column;
+    };
+  //BLOCK OF CONTIGUOUS DATA IN MATRIX
+
+  template<typename T, std::size_t Rows, std::size_t Columns>
+      //VERSION WITH MAXIMUM POSSIBLE CACHE HIT
+      //ANALYZE BLOCK STRUCTURE WHERE THIS STYLE IS PREFFERED
+      class nested{
+        public:
+          using value_type = T;
+          using size_type = std::size_t;
+          using reference = T&;
+          using const_reference = const T&;
+          using pointer = T*;
+          using const_pointer = const T*;
+
+          nested()=default;
+          nested(const nested&)=default;
+          nested(nested&&)=default;
+          nested& operator=(nested&&)=default;
+          nested& operator=(const nested&)=default;
+
+          nested(std::initializer_list<std::initializer_list<T>> elements){
+
+            for(auto row=std::begin(elements); row!=std::end(elements); ++row){
+              std::size_t elements_counter = 0;
+              const auto iterator_position{std::distance(std::begin(elements), row)};
+
+              for(auto col=row->begin(), end=row->end(); col!=end; ++col){
+                if(*col != 0){
+                  inner_block<T> chain{};
+                  chain.column = elements_counter;
+
+                  while((*col != 0) && (col!=end)){
+                    chain.data.push_back(*col);
+                    ++elements_counter;
+                    ++col;
+                  }
+                  matrix[iterator_position].emplace_back(chain);
+                }
+                ++elements_counter;
+              }
+            }
+          }
+
+          size_type size() const noexcept{
+            return matrix.size();
+          }
+
+          const std::array<std::vector<inner_block<T>>, Rows>& data() const noexcept{
+            return matrix;
+          }
+
+          std::array<std::vector<inner_block<T>>, Rows>& data() noexcept{
+            return matrix;
+          }
+
+          template<typename U>
+            auto operator*(const numpp::vector<U,Columns, false>& vec){
+              vector<U,Rows,false> output{};
+
+              #pragma omp for schedule(simd:dynamic)
+              for(std::size_t row=0; row<Rows; ++row){
+
+                for(std::size_t inner_block=0, block_end=matrix[row].size(); inner_block<block_end; ++inner_block){
+
+                  const std::size_t col=matrix[row][inner_block].column;
+                  const std::size_t element_end=matrix[row][inner_block].data.size();
+                  #pragma omp simd
+                  for(std::size_t element=0; element<element_end; ++element){
+                    output(row) += matrix[row][inner_block].data[element]*vec(col+element);
+                  }
+                }
+
+              }
+              return output;
+            }
+
+        private:
+          std::array<std::vector<inner_block<T>>, Rows> matrix{};
+      };
+}
+
+#endif


### PR DESCRIPTION
1. Nested sparse matrix
+ Less operations for matrix*vector
- Additional level of indirection in vector access
- Possible worse cache hit rate

2. Block sparse matrix
- More operations for matrix*vector (and additional cast for every block)
+ Only one level of indirection with vector
+ Good alignment and small cache rate misses

TO DO:
- Testing
- compile-time Compressed Sparse Row implementation