### PR TITLE
Add symbolic type differentiation

### DIFF
--- a/differentiation/symbolic/arithmetic.hpp
+++ b/differentiation/symbolic/arithmetic.hpp
@@ -5,205 +5,143 @@
 #include<type_traits>
 
 #include"types.hpp"
+#include"simplificator.hpp"
+
+#if defined  __GNUC__ && !defined __clang__
+  #define CONSTEXPR constexpr
+#elif
+  #define CONSTEXPR
+#endif
 
 /* 'Abandon All Hope, Ye Who Enter Here' ~XTerm README */
 
 namespace numpp::differentiation::symbolic{
-  template<typename... Dummy> class minus;
-  template<typename T> class minus<T>;
-  template<typename T, typename U> class minus<T, U>;
+  template<typename T> class minus;
+  template<typename Left, typename Right> class subtract;
 
-  template<typename Left, typename Right> class plus;
+  template<typename Left, typename Right> class add;
   template<typename Left, typename Right> class multiply;
   template<typename Left, typename Right> class divide;
+
+  template<typename Left, int Exp>
+    class power{
+      public:
+        template<std::size_t Active>
+          using derivative = simplify_multiplication<
+                              multiply<constant<Exp>, power<Left, Exp-1>>,
+                              typename Left::template derivative<Active>
+                             >;
+        CONSTEXPR static auto calculate(auto&& values){
+          return std::pow(Left::calculate(values), Exp);
+        }
+    };
 
   template<typename Left, typename Right>
     class divide{
       public:
-        using derivative = std::conditional_t<
-          typename Left::active{},
-          std::conditional_t<
-            typename Right::active{},
-              divide<
-                minus<multiply<typename Left::derivative, Right>, multiply<Left, typename Right::derivative>>,
-                multiply<Right, Right>
-              >,
-              divide<typename Left::derivative, Right>
-          >,
-          std::conditional_t<
-            typename Right::active{},
-              divide<Left, typename Right::derivative>,
-              divide<Left, Right>
-            >
-          >;
+        template<std::size_t Active>
+          using derivative =
+                simplify_division<
+                  simplify_subtraction<
+                    simplify_multiplication<typename Left::template derivative<Active>, Right>,
+                    simplify_multiplication<Left, typename Right::template derivative<Active>>>,
+                  power<Right, 2>
+                >;
 
-        using active = std::conditional_t<
-          typename Left::active{} || typename Right::active{},
-          std::true_type,
-          std::false_type
-        >;
-
-        using type = std::conditional_t<
-          std::is_arithmetic<typename Left::type>::value,
-          typename Right::type,
-          typename Left::type
-        >;
-
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return left(value)/right(value);
-          }
-      private:
-        const Left left{};
-        const Right right{};
+        constexpr static auto calculate(auto&& values){
+          return Left::calculate(values) / Right::calculate(values);
+        }
     };
 
   template<typename Left, typename Right>
     class multiply{
       public:
-        using derivative = std::conditional_t<
-          typename Left::active{},
-          std::conditional_t<
-            typename Right::active{},
-              plus<multiply<typename Left::derivative, Right>, multiply<Left, typename Right::derivative>>,
-              multiply<Right, typename Left::derivative>
-          >,
-          std::conditional_t<
-            typename Right::active{},
-              multiply<Left, typename Right::derivative>,
-              multiply<Left, Right>
-          >
-        >;
+        template<std::size_t Active>
+          using derivative =
+                simplify_addition<
+                  simplify_multiplication<
+                    typename Left::template derivative<Active>,
+                    Right
+                  >,
+                  simplify_multiplication<
+                    Left,
+                    typename Right::template derivative<Active>
+                  >
+                >;
 
-
-        using active = std::conditional_t<
-          typename Left::active{} || typename Right::active{},
-          std::true_type,
-          std::false_type
-        >;
-
-        using type = std::conditional_t<
-          std::is_arithmetic<typename Left::type>::value,
-          typename Right::type,
-          typename Left::type
-        >;
-
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return left(value)*right(value);
-          }
-
-        template<typename U>
-          constexpr U operator()(U left_value, U right_value)const{
-            return left(left_value)*right(right_value);
-          }
-
-      private:
-        const Left left{};
-        const Right right{};
+        constexpr static auto calculate(auto&& values){
+          return Left::calculate(values) * Right::calculate(values);
+        }
     };
 
 
   template<typename Left, typename Right>
-    class plus{
+    class add{
       public:
-        using active = std::conditional_t<
-          typename Left::active{} || typename Right::active{},
-          std::true_type,
-          std::false_type
-        >;
-        using type = std::conditional_t<
-          std::is_arithmetic<typename Left::type>::value,
-          typename Right::type,
-          typename Left::type
-        >;
-        using derivative = std::conditional_t<
-                        typename Left::active{},
-                          std::conditional_t<
-                            typename Right::active{},
-                              plus<typename Left::derivative, typename Right::derivative>,
-                              typename Left::derivative
-                          >,
-                          std::conditional_t<
-                            typename Right::active{},
-                              typename Right::derivative,
-                              none
-                          >
-                        >;
+        template<std::size_t Active>
+          using derivative = simplify_addition<
+                              typename Left::template derivative<Active>,
+                              typename Right::template derivative<Active>
+                             >;
 
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return left(value) + right(value);
-          }
-
-        template<typename U>
-          constexpr U operator()(U left_value, U right_value)const{
-            return left(left_value) + right(right_value);
-          }
-
-      private:
-        const Left left{};
-        const Right right{};
+        constexpr static auto calculate(auto&& values){
+          return Left::calculate(values) + Right::calculate(values);
+        }
     };
 
   template<typename Left, typename Right>
-    class minus<Left,Right>{
+    class subtract{
       public:
-        //ACTIVE ALWAYS TRUE?
-        using active = std::conditional_t<
-          typename Left::active{} || typename Right::active{},
-          std::true_type,
-          std::false_type
-        >;
-        using type = std::conditional_t<
-          std::is_arithmetic<typename Left::type>::value,
-          typename Right::type,
-          typename Left::type
-        >;
-        using derivative = std::conditional_t<
-                        typename Left::active{},
-                          std::conditional_t<
-                            typename Right::active{},
-                              minus<typename Left::derivative, typename Right::derivative>,
-                              typename Left::derivative
-                          >,
-                          std::conditional_t<
-                            typename Right::active{},
-                              minus<typename Right::derivative>,
-                              none
-                          >
-                        >;
+        template<std::size_t Active>
+          using derivative = simplify_subtraction<
+                              typename Left::template derivative<Active>,
+                              typename Right::template derivative<Active>
+                             >;
 
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return left(value) - right(value);
-          }
+        constexpr static auto calculate(auto&& values){
+          return Left::calculate(values) - Right::calculate(values);
+        }
 
-        template<typename U>
-          constexpr U operator()(U left_value, U right_value)const{
-            return left(left_value) - right(right_value);
-          }
-
-      private:
-        const Left left{};
-        const Right right{};
     };
 
   template<typename T>
-    class minus<T>{
+    class minus{
       public:
-        using derivative = minus<typename T::derivative>;
-        using active = typename T::active;
-        using type = T;
+        template<std::size_t Active>
+          using derivative = simplify_minus<typename T::template derivative<Active>>;
 
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return - inner(value);
-          }
+        constexpr static auto calculate(auto&& values){
+          return - T::calculate(values);
+        }
 
-      private:
-        const T inner{};
     };
+
+  //TEMPLATE OVERLOADS FOR READABILITY
+
+  template<typename Left, typename Right>
+    constexpr add<Left, Right> operator+(const Left&, const Right&){
+      return add<Left, Right>{};
+    }
+
+  template<typename Left, typename Right>
+    constexpr subtract<Left, Right> operator-(const Left&, const Right&){
+      return subtract<Left, Right>{};
+    }
+
+  template<typename T>
+    constexpr minus<T> operator-(const T&){
+      return minus<T>{};
+    }
+
+  template<typename Left, typename Right>
+    constexpr multiply<Left, Right> operator*(const Left&, const Right&){
+      return multiply<Left, Right>{};
+    }
+
+  template<typename Left, typename Right>
+    constexpr divide<Left, Right> operator/(const Left&, const Right&){
+      return divide<Left, Right>{};
+    }
 
 }
 

--- a/differentiation/symbolic/exponential.hpp
+++ b/differentiation/symbolic/exponential.hpp
@@ -5,51 +5,49 @@
 #include<cmath>
 #include"types.hpp"
 #include"arithmetic.hpp"
+#include"simplificator.hpp"
+
+#if defined  __GNUC__ && !defined __clang__
+  #define CONSTEXPR constexpr
+#elif
+  #define CONSTEXPR
+#endif
 
 namespace numpp::differentiation::symbolic{
   template<typename T>
-    class log{
+    class logarithm{
       public:
-        using active = typename T::active;
-        using type = log<T>;
+        template<std::size_t Active>
+          using derivative = simplify_division<typename T::template derivative<Active>, T>;
 
-        using derivative = std::conditional_t<
-          typename T::active{},
-            std::conditional_t<
-              std::is_arithmetic<typename T::type>::value,
-                divide<constant<1>, T>,
-                multiply<divide<constant<1>, T>, typename T::derivative>
-            >,
-            log<T>
-        >;
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return std::log(inner(value));
-          }
-
-      private:
-        const T inner{};
+        CONSTEXPR static auto calculate(auto&& values){
+          return std::log(T::calculate(values));
+        }
     };
 
   template<typename T>
-    class exp{
+    class exponential{
       public:
         using active = typename T::active;
-        using type = exp<T>;
+        using type = exponential<T>;
 
-        using derivative = std::conditional_t<
-              std::is_arithmetic<typename T::type>::value,
-                exp<T>,
-                multiply<exp<T>, typename T::derivative>
-        >;
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return std::exp(inner(value));
-          }
+        template<std::size_t Active>
+        using derivative = multiply<exponential<T>, typename T::template derivative<Active>>;
 
-      private:
-        const T inner{};
+        CONSTEXPR static auto calculate(auto&& values){
+          return std::log(T::calculate(values));
+        }
     };
+
+  template<typename T>
+    CONSTEXPR exponential<T> exp(const T&){
+      return exponential<T>{};
+    }
+
+  template<typename T>
+    CONSTEXPR logarithm<T> log(const T&){
+      return logarithm<T>{};
+    }
 
 }
 

--- a/differentiation/symbolic/functions.hpp
+++ b/differentiation/symbolic/functions.hpp
@@ -1,0 +1,30 @@
+#ifndef NUMPP_SYMBOLIC_FUNCTIONS_HPP_
+#define NUMPP_SYMBOLIC_FUNCTIONS_HPP_
+
+#include"arithmetic.hpp"
+
+namespace numpp::differentiation::symbolic{
+  //DIFFERENTIATE N-TH ORDER WITH RESPECT TO GIVEN VARIABLES
+  //OVERALL RECURSIVE CASE
+  template<typename Function, std::size_t Order>
+    class differentiate{
+      public:
+      template<std::size_t Variable, std::size_t... Variables>
+        using with_respect_to =
+          typename differentiate<typename Function::template derivative<Variable>, Order-1>::template with_respect_to<Variables...>;
+
+    };
+
+  //BASE RECURSIVE CASE
+  template<typename Function>
+    class differentiate<Function, 1>{
+      public:
+        template<std::size_t Variable>
+          using with_respect_to =
+            typename Function::template derivative<Variable>;
+
+    };
+
+}
+
+#endif

--- a/differentiation/symbolic/simplificator.hpp
+++ b/differentiation/symbolic/simplificator.hpp
@@ -1,0 +1,286 @@
+#ifndef NUMPP_DIFFERENTIATION_SYMBOLIC_SIMPLIFIER_HPP_
+#define NUMPP_DIFFERENTIATION_SYMBOLIC_SIMPLIFIER_HPP_
+
+#include"types.hpp"
+
+namespace numpp::differentiation::symbolic{
+  template<typename Left, typename Right> class multiply;
+  template<typename T> class minus;
+  template<typename Left, typename Right> class subtract;
+
+  template<typename Left, typename Right> class add;
+  template<typename Left, typename Right> class divide;
+
+  namespace impl{
+    //MAIN CLASS
+    template<typename Left, typename Right> class simplify_multiplication{
+      public:
+      using type = multiply<Left, Right>;
+    };
+
+    //MULTIPLY SIMPLIFICATION
+    //MULTIPLICATION TIMES ONE
+    template<typename Left>
+      class simplify_multiplication<Left, constant<1>>{
+        public:
+        using type = Left;
+      };
+
+    template<typename Right>
+      class simplify_multiplication<constant<1>, Right>{
+        public:
+        using type = Right;
+      };
+
+    //MULTIPLICATION TIMES ZERO
+    template<typename Left>
+      class simplify_multiplication<Left, constant<0>>{
+        public:
+        using type = constant<0>;
+      };
+
+    template<typename Left>
+      class simplify_multiplication<Left, minus<constant<0>>>{
+        public:
+        using type = constant<0>;
+      };
+
+    template<typename Right>
+      class simplify_multiplication<constant<0>, Right>{
+        public:
+        using type = constant<0>;
+      };
+
+    template<typename Right>
+      class simplify_multiplication<minus<constant<0>>, Right>{
+        public:
+        using type = constant<0>;
+      };
+
+    //VALUE TIMES VALUE MULTIPLICATION
+    template<int left_value, int right_value>
+      class simplify_multiplication<constant<left_value>, constant<right_value>>{
+        public:
+        using type = constant<left_value*right_value>;
+      };
+
+    //VALUE OUTSIDE OF FUNCTIONS
+    template<typename T, int left_value, int right_value>
+      class simplify_multiplication<
+        multiply<T, constant<left_value>>,
+        constant<right_value>
+      >{
+        public:
+        using type = multiply<T, constant<left_value*right_value>>;
+      };
+
+    template<typename T, int left_value, int right_value>
+      class simplify_multiplication<
+        constant<left_value>,
+        multiply<T, constant<right_value>>
+      >{
+        public:
+        using type = multiply<T, constant<left_value*right_value>>;
+      };
+
+    //DIVISION WITH MULTIPLICATION
+    template<typename First, typename Second>
+      class simplify_multiplication<
+        First,
+        divide<constant<1>, Second>
+      >{
+        public:
+        using type = divide<First, Second>;
+      };
+
+    //MINUS MULTIPLICATION
+    template<typename First, typename Second>
+      class simplify_multiplication<minus<First>, minus<Second>>{
+        public:
+          using type = multiply<First, Second>;
+
+      };
+
+  }
+
+  template<typename Left, typename Right>
+    using simplify_multiplication = typename impl::simplify_multiplication<Left, Right>::type;
+
+  //ADDITION SIMPLIFICATION
+
+  namespace impl{
+    template<typename Left, typename Right>
+      class simplify_addition{
+        public:
+        using type = add<Left, Right>;
+      };
+
+    template<typename Left>
+      class simplify_addition<Left, constant<0>>{
+        public:
+        using type = Left;
+      };
+
+    template<typename Right>
+      class simplify_addition<constant<0>, Right>{
+        public:
+        using type = Right;
+      };
+
+    //ADDITION OF MINUS
+    template<typename Left, typename Right>
+      class simplify_addition<Left, minus<Right>>{
+        public:
+        using type = subtract<Left, Right>;
+      };
+
+    //OUTSIDE OF REALM SIMPLIFICATION
+    template<typename Left, int left_value, int right_value>
+      class simplify_addition<
+        constant<left_value>,
+        add<Left, constant<right_value>>
+      >{
+        public:
+        using type = add<Left, constant<left_value+right_value>>;
+      };
+
+    template<typename Left, int left_value, int right_value>
+      class simplify_addition<
+        add<Left, constant<left_value>>,
+        constant<right_value>
+      >{
+        public:
+        using type = add<Left, constant<left_value+right_value>>;
+      };
+
+    template<typename Right, int left_value, int right_value>
+      class simplify_addition<
+        constant<left_value>,
+        add<constant<right_value>, Right>
+      >{
+        public:
+        using type = add<Right, constant<left_value+right_value>>;
+      };
+
+    template<typename Right, int left_value, int right_value>
+      class simplify_addition<
+        add<constant<left_value>, Right>,
+        constant<right_value>
+      >{
+        public:
+        using type = add<Right, constant<left_value+right_value>>;
+      };
+
+  }
+
+  template<typename Left, typename Right>
+    using simplify_addition = typename impl::simplify_addition<Left, Right>::type;
+
+  //SIMPLIFY MINUS
+
+  namespace impl{
+    template<typename T>
+      class simplify_minus{
+        public:
+        using type = minus<T>;
+      };
+
+    template<>
+    class simplify_minus<minus<constant<0>>>{
+      public:
+      using type = constant<0>;
+    };
+
+    template<typename T>
+      class simplify_minus<minus<T>>{
+        public:
+        using type = T;
+      };
+
+    template<typename Left, typename Right>
+      class simplify_minus<minus<subtract<Left, Right>>>{
+        public:
+        using type = subtract<Right, Left>;
+      };
+
+  }
+
+  template<typename T>
+    using simplify_minus = typename impl::simplify_minus<T>::type;
+
+  //SIMPLIFY SUBTRACTION
+
+  namespace impl{
+    template<typename Left, typename Right>
+      class simplify_subtraction{
+        public:
+        using type = subtract<Left, Right>;
+      };
+
+    template<typename Left, typename Right>
+      class simplify_subtraction<Left, minus<Right>>{
+        public:
+        using type = add<Left, Right>;
+      };
+  }
+
+  template<typename Left, typename Right>
+    using simplify_subtraction = typename impl::simplify_subtraction<Left, Right>::type;
+
+  //SIMPLIFY DIVISION
+  namespace impl{
+    template<typename Upper, typename Lower>
+      class simplify_division{
+        public:
+        using type = divide<Upper, Lower>;
+      };
+
+    template<typename First, typename Second>
+      class simplify_division<multiply<First, Second>, Second>{
+        public:
+        using type = First;
+      };
+
+    template<typename First, typename Second>
+      class simplify_division<First, multiply<First, Second>>{
+        public:
+        using type = divide<constant<1>, Second>;
+      };
+
+    template<typename First, typename Second, typename Third>
+      class simplify_division<multiply<First, Second>, multiply<Second, Third>>{
+        public:
+        using type = divide<First, Third>;
+      };
+
+    template<typename T>
+      class simplify_division<T, T>{
+        public:
+        using type = constant<1>;
+      };
+
+    template<typename T>
+      class simplify_division<T, constant<1>>{
+        public:
+        using type = T;
+      };
+
+    template<typename T>
+      class simplify_division<constant<0>, T>{
+        public:
+        using type = constant<0>;
+      };
+
+    template<typename First, typename Second>
+      class simplify_division<constant<1>, divide<First, Second>>{
+        public:
+        using type = divide<Second, First>;
+      };
+
+  }
+
+  template<typename Left, typename Right>
+    using simplify_division = typename impl::simplify_division<Left, Right>::type;
+}
+
+#endif

--- a/differentiation/symbolic/trigonometric.hpp
+++ b/differentiation/symbolic/trigonometric.hpp
@@ -6,86 +6,52 @@
 
 #include"arithmetic.hpp"
 
+#if defined  __GNUC__ && !defined __clang__
+#define CONSTEXPR constexpr
+#elif
+#define CONSTEXPR
+#endif
+
 namespace numpp::differentiation::symbolic{
-  template<typename T> class cos;
+  template<typename T> class cosinus;
   template<typename T>
-    class sin{
+    class sinus{
       public:
-        using active = typename T::active;
-        using type = sin<T>;
+        template<std::size_t Active>
+          using derivative = simplify_multiplication<
+          cosinus<T>,
+          typename T::template derivative<Active>
+            >;
 
-        using derivative = std::conditional_t<
-          //ARE WE DIFFERENTIATING BY THIS VALUE?
-          typename T::active{},
-            //YES
-            std::conditional_t<
-              //IS THE TYPE INSIDE AN ARITHMETIC ONE? IF YES, THAN IT'S A SIMPLE DERIVATIVE
-              std::is_arithmetic<typename T::type>::value,
-                //IS NOT FUNCTION, SIMPLE DERIVATIVE
-                cos<T>,
-                //IS FUNCTION, NESTED DERIVATIVE
-                multiply<cos<T>, typename T::derivative>
-            >,
-            //NOT DIFFERENTIATING BY THIS VALUE, RETURN AS IS
-            sin<T>
-        >;
-
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return std::sin(inner(value));
-          }
-
-      private:
-        const T inner{};
+        CONSTEXPR static auto calculate(auto&& values){
+          return std::sin(T::calculate(values));
+        }
     };
 
   template<typename T>
-    class cos{
+    class cosinus{
       public:
-        using active = typename T::active;
-        using type = cos<T>;
+        template<std::size_t Active>
+          using derivative =
+          simplify_multiplication<
+          minus<sinus<T>>,
+          typename T::template derivative<Active>
+            >;
 
-        using derivative = std::conditional_t<
-          typename T::active{},
-            std::conditional_t<
-              std::is_arithmetic<typename T::type>::value,
-                minus<sin<T>>,
-                multiply<minus<sin<T>>, typename T::derivative>
-            >,
-            cos<T>
-        >;
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return std::cos(inner(value));
-          }
-
-      private:
-        const T inner{};
+        CONSTEXPR static auto calculate(auto&& values){
+          return std::sin(T::calculate(values));
+        }
     };
 
-  //TO DO
   template<typename T>
-    class tan{
-      public:
-        using active = typename T::active;
-        using type = cos<T>;
+    CONSTEXPR sinus<T> sin(const T&){
+      return sinus<T>{};
+    }
 
-        using derivative = std::conditional_t<
-          typename T::active{},
-            std::conditional_t<
-              std::is_arithmetic<typename T::type>::value,
-                minus<sin<T>>,
-                multiply<minus<sin<T>>, typename T::derivative>
-            >,
-            cos<T>
-        >;
-        template<typename U>
-          constexpr U operator()(U value)const{
-            return std::cos(inner(value));
-          }
+  template<typename T>
+    CONSTEXPR cosinus<T> cos(const T&){
+      return cosinus<T>{};
+    }
 
-      private:
-        const T inner{};
-    };
 }
 #endif

--- a/differentiation/symbolic/types.hpp
+++ b/differentiation/symbolic/types.hpp
@@ -4,49 +4,37 @@
 #include<type_traits>
 
 namespace numpp::differentiation::symbolic{
-  template<typename T>
-    class variable{
-      public:
-        using active = std::true_type;
-        using derivative = variable<T>;
-        using type = T;
-
-        constexpr T operator()(T value)const{
-          return value;
-        }
-    };
-
-  template<typename T>
-    class inactive{
-      public:
-        using active = std::false_type;
-        using derivative = inactive<T>;
-        using type = T;
-
-        constexpr T operator()(T variable)const{
-          return variable;
-        }
-    };
-
-  class none{
-    template<typename U>
-      constexpr U operator()(U dummy...){
-        return 0;
-      }
-  };
 
   template<int Value>
     class constant{
-      using active = std::false_type;
-      using derivative = none;
-      using type = int;
+      public:
+        using active = std::false_type;
+        template<std::size_t Active> using derivative = constant<0>;
+        using type = int;
 
-      template<typename ...U>
-        constexpr int operator()(U ...){
+        constexpr static int calculate(auto&&){
           return Value;
         }
 
     };
+
+  template<typename T, std::size_t Number>
+    class variable{
+      public:
+        template<std::size_t Active>
+          using derivative = std::conditional_t<
+          Active==Number,
+          constant<1>,
+          constant<0>
+        >;
+
+        constexpr static auto calculate(auto&& values){
+          return values[Number];
+        }
+    };
+
+  template<std::size_t Number> using x = variable<double, Number>;
+
 
 }
 


### PR DESCRIPTION
Updated idea with research from the paper:
https://arxiv.org/pdf/1705.01729.pdf

Improved upon the version showcased above:
- No object creation during type derivation
- Partial derivatives of any order in any combination
- Probably faster execution and up-to-date implementation
- Additional simplifiers

TO DO:
- Extensive speed testing
- Additional functions for bigger variety of possibilities